### PR TITLE
Added depends to plugin.xml for multi-platform support

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -66,6 +66,8 @@
 
     <idea-version since-build="135"/>
 
+    <depends>com.intellij.modules.lang</depends>
+    
     <extensions defaultExtensionNs="com.intellij">
         <applicationService serviceImplementation="com.dubreuia.Settings"/>
         <applicationConfigurable instance="com.dubreuia.Configuration"/>


### PR DESCRIPTION
Updated the plugin.xml to work with WebStorm.  I have only been able to test with WebStorm 11, but it works great.
