### PR TITLE
Executes Save Actions on multiple files

### DIFF
--- a/src/main/java/com/dubreuia/core/SaveActionBatchAction.java
+++ b/src/main/java/com/dubreuia/core/SaveActionBatchAction.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2000-2016 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dubreuia.core;
+
+import com.dubreuia.processors.ProcessorACCESSOR;
+import com.intellij.analysis.AnalysisScope;
+import com.intellij.analysis.BaseAnalysisAction;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Runs the save actions on the given scope of files. The user is asked for the scope using a standard IDEA dialog.
+ * <p>
+ * Originally based on https://github.com/JetBrains/intellij-community/blob/master/java/java-impl/src/com/intellij/codeInspection/inferNullity/InferNullityAnnotationsAction.java
+ *
+ * @author markiewb
+ */
+public class SaveActionBatchAction extends BaseAnalysisAction {
+
+    public static final Logger LOGGER = Logger.getInstance(SaveActionBatchAction.class);
+
+    public SaveActionBatchAction() {
+        super("Save Actions", "Save Actions");
+    }
+
+    @Override
+    protected void analyze(@NotNull Project project, @NotNull AnalysisScope scope) {
+
+        List<SaveActionManager> saveActionManagers = SaveActionFactory.getSaveActionManagers();
+        LOGGER.debug("Running Save Actions on multiple files " + scope);
+        AtomicLong fileCount = new AtomicLong();
+        scope.accept(new PsiElementVisitor() {
+            @Override
+            public void visitFile(PsiFile psiFile) {
+                super.visitFile(psiFile);
+                fileCount.incrementAndGet();
+
+                for (SaveActionManager saveActionManager : saveActionManagers) {
+                    saveActionManager.checkAndProcessPsiFile(project, psiFile,
+                            //don't compile in a batch action
+                            x -> !ProcessorACCESSOR.getCompileProcessorClass().isInstance(x));
+                }
+            }
+        });
+        LOGGER.debug("Ran Save Actions on " + fileCount.get() + " files ");
+
+    }
+
+
+}

--- a/src/main/java/com/dubreuia/processors/ProcessorACCESSOR.java
+++ b/src/main/java/com/dubreuia/processors/ProcessorACCESSOR.java
@@ -1,0 +1,10 @@
+package com.dubreuia.processors;
+
+/**
+ * ACCESSOR to get access to hidden classes in this package.
+ */
+public final class ProcessorACCESSOR {
+    public static Class<? extends Processor> getCompileProcessorClass() {
+        return CompileProcessor.class;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -79,5 +79,11 @@
         </action>
         <action class="com.dubreuia.core.SaveActionToggleAction" id="com.dubreuia.core.SaveActionToggleAction"
                 text="Enable Save Actions" description="Toggle the activation of Save Actions"/>
+
+        <action id="SaveActionBatchAction" class="com.dubreuia.core.SaveActionBatchAction"
+                text="Save Actions..." description="Executes Save Actions on multiple files">
+            <add-to-group group-id="CodeFormatGroup" anchor="after"
+                          relative-to-action="com.dubreuia.core.SaveActionShortcutManager"/>
+        </action>
     </actions>
 </idea-plugin>


### PR DESCRIPTION
* Adds a new action "Menu/Code/Save Actions...", which asks the user for the scope (f.e. whole project or current file or custom scope) and executes the save action on the files of the given scope
* Note that the CompilerProcessor has been excluded to prevent piling up of compiler tasks. IDEA will nevertheless compile the changed files within the next build execution

Such an action has been requested several times IIRC. Like in #169.
My use-case is to format, organize imports, rearrange and add @overrides to all files in the project in a batch. A workaround would be to create a clean up rule inspection profile, enable only my requested fixes and execute it on the scope of files. But rearrange, organize imports nor format are available as such a rule and thus cannot be included in a profile. 

I am not quite happy with the menu entry name "Save Actions...". Perhaps "Run Save Actions on Multiple Files..." is a better name? Any suggestions or preferences?

@dubreuia: Please review the change.