### PR TITLE
Fix #168, final will be not added to try-with-resources resources.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'org.jetbrains.intellij'
 
 // Add intellij task configuration for base intellij version (minimum compatibility)
 intellij {
-    version '2016.3'
+    version '2018.1'
     plugins 'coverage'
     pluginName 'Save Actions'
     // Do not touch the plugin.xml file

--- a/src/main/java/com/dubreuia/processors/java/JavaProcessor.java
+++ b/src/main/java/com/dubreuia/processors/java/JavaProcessor.java
@@ -43,7 +43,11 @@ public enum JavaProcessor implements Processor {
             FieldMayBeFinalInspection::new),
 
     localCanBeFinal(Action.localCanBeFinal,
-            LocalCanBeFinal::new),
+            () -> {
+                final LocalCanBeFinal inspection = new LocalCanBeFinal();
+                inspection.REPORT_IMPLICIT_FINALS = false;
+                return inspection;
+            }),
 
     methodMayBeStatic(Action.methodMayBeStatic,
             MethodMayBeStaticInspection::new),

--- a/src/test/java/com/dubreuia/integration/ActionTestFile.java
+++ b/src/test/java/com/dubreuia/integration/ActionTestFile.java
@@ -65,6 +65,8 @@ public enum ActionTestFile {
     InspectionsAll_KO,
     InspectionsAll_OK,
 
+    TryWithResourcesWithoutFinal_KO,
+    TryWithResourcesWithoutFinal_OK,
     //
     ;
 

--- a/src/test/java/com/dubreuia/integration/JavaIntegrationTest.java
+++ b/src/test/java/com/dubreuia/integration/JavaIntegrationTest.java
@@ -25,6 +25,8 @@ import static com.dubreuia.integration.ActionTestFile.MissingOverrideAnnotation_
 import static com.dubreuia.integration.ActionTestFile.MissingOverrideAnnotation_OK;
 import static com.dubreuia.integration.ActionTestFile.SuppressAnnotation_KO;
 import static com.dubreuia.integration.ActionTestFile.SuppressAnnotation_OK;
+import static com.dubreuia.integration.ActionTestFile.TryWithResourcesWithoutFinal_KO;
+import static com.dubreuia.integration.ActionTestFile.TryWithResourcesWithoutFinal_OK;
 import static com.dubreuia.integration.ActionTestFile.UnnecessaryFinalOnLocalVariableOrParameter_KO;
 import static com.dubreuia.integration.ActionTestFile.UnnecessaryFinalOnLocalVariableOrParameter_OK;
 import static com.dubreuia.integration.ActionTestFile.UnnecessarySemicolon_KO;
@@ -61,6 +63,13 @@ import static com.dubreuia.model.Action.unqualifiedStaticMemberAccess;
 import static com.dubreuia.model.Action.useBlocks;
 
 class JavaIntegrationTest extends IntegrationTest {
+
+    @Test
+    void shouldnt_tryWithResourcesWithoutFinal_add_final_to_resource() {
+        storage.setEnabled(activate, true);
+        storage.setEnabled(localCanBeFinal, true);
+        assertSaveAction(TryWithResourcesWithoutFinal_KO, TryWithResourcesWithoutFinal_OK);
+    }
 
     @Test
     void should_fieldCanBeFinal_add_final_to_field() {

--- a/src/test/resources/com/dubreuia/integration/TryWithResourcesWithoutFinal_KO.java
+++ b/src/test/resources/com/dubreuia/integration/TryWithResourcesWithoutFinal_KO.java
@@ -1,0 +1,20 @@
+package com.dubreuia.integration;
+
+public class Class {
+
+    private void method() {
+        try (Resource r = new Resource()) {
+
+        }
+    }
+
+    class Resource implements AutoCloseable {
+
+        @Override
+        public void close() {
+
+        }
+
+    }
+
+}

--- a/src/test/resources/com/dubreuia/integration/TryWithResourcesWithoutFinal_OK.java
+++ b/src/test/resources/com/dubreuia/integration/TryWithResourcesWithoutFinal_OK.java
@@ -1,0 +1,20 @@
+package com.dubreuia.integration;
+
+public class Class {
+
+    private void method() {
+        try (Resource r = new Resource()) {
+
+        }
+    }
+
+    class Resource implements AutoCloseable {
+
+        @Override
+        public void close() {
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
Bumped intellij task minimum version to 2018.1 (REPORT_IMPLICIT_FINALS
is introduced in 2017.2 but test passes without changes)