### PR TITLE
Fix for missing @NonInjectable exception

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,9 +12,9 @@ The code branches are based on "since-build" properties (except master).
     - tag and github release: **1.5.0+2018.3**
     - build.gradle: `version: '2018.3'`
     - plugin.xml: `<idea-version since-build="183"/>` (no until)
-- Branch `master` with no version or tags, idea version **2019.1** (LATEST), no release of this branch
-    - build.gradle: `version: '2019.1'`
-    - plugin.xml: `<idea-version since-build="191"/>`
+- Branch `master` with no version or tags, idea version **2019.3** (LATEST), no release of this branch
+    - build.gradle: `version: '2019.3'`
+    - plugin.xml: `<idea-version since-build="193"/>`
 
 ## Reporting
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
 // Add idea plugin version
 plugins {
-    id "org.jetbrains.intellij" version "0.3.3"
+    id "org.jetbrains.intellij" version "0.4.10"
 }
 
 // Add idea and java plugins
@@ -19,8 +19,8 @@ apply plugin: 'org.jetbrains.intellij'
 // Add intellij task configuration for base intellij version (minimum compatibility)
 // This needs to fit the tag <idea-version since-build="181"> in plugin.xml
 intellij {
-    version '2019.1'
-    plugins 'coverage'
+    version '193.3519.25-EAP-SNAPSHOT'
+    plugins = ['java', 'coverage']
     pluginName 'Save Actions'
     // Do not touch the plugin.xml file
     updateSinceUntilBuild false

--- a/src/main/java/com/dubreuia/model/Storage.java
+++ b/src/main/java/com/dubreuia/model/Storage.java
@@ -2,6 +2,7 @@ package com.dubreuia.model;
 
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
+import com.intellij.serviceContainer.NonInjectable;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,7 +13,8 @@ import java.util.Set;
 
 @State(name = "SaveActionSettings",
         storages = {@com.intellij.openapi.components.Storage(file = "./saveactions_settings.xml")})
-public class Storage implements PersistentStateComponent<Storage> {
+public class Storage
+        implements PersistentStateComponent<Storage> {
 
     private boolean firstLaunch;
     private Set<Action> actions;
@@ -30,6 +32,7 @@ public class Storage implements PersistentStateComponent<Storage> {
         quickLists = new ArrayList<>();
     }
 
+    @NonInjectable
     public Storage(Storage storage) {
         firstLaunch = storage.firstLaunch;
         actions = new HashSet<>(storage.actions);

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -55,7 +55,7 @@
     ]]>
     </change-notes>
 
-    <idea-version since-build="191"/>
+    <idea-version since-build="193"/>
 
     <!-- Other product support activated in plugin page during upload at https://plugins.jetbrains.com -->
     <depends optional="true" config-file="plugin-java.xml">com.intellij.modules.java</depends>


### PR DESCRIPTION
Check List -

- [x] Figure out how to include latest IntelliJ platform
- [x] Figure out why `com.intellij.debugger.*` classes are missing with version >= `2019.2`
- [x] Correctly format the changes as per recommended settings 
- [x] Manual testing of the fix
- [ ] Add test(s) (if applicable)
- [x] Documentation update


**Changes**

1. Updated `org.jetbrains.intellij` gradle plugin to `v0.4.10`.
1. IntelliJ platform updated to version `193.3519.25-EAP-SNAPSHOT`.
1. Added `java`  IntelliJ plugin.
1. Updated supported plugin version to `193` i.e. IntelliJ IDEA `2019.3` or later.
1. Added `@NonInjectable` to the problematic constructor in `com.dubreuia.model.Storage`.

**References**

1. https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/
1. https://github.com/JetBrains/gradle-intellij-plugin
1. https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html

See also https://github.com/dubreuia/intellij-plugin-save-actions/pull/262.
Depends on https://github.com/dubreuia/intellij-plugin-save-actions/pull/262.

Fixes gh-259