### PR TITLE
Specified maximum supported platform version

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,6 +12,10 @@ The code branches are based on "since-build" properties (except master).
     - tag and github release: **1.5.0+2018.3**
     - build.gradle: `version: '2018.3'`
     - plugin.xml: `<idea-version since-build="183"/>` (no until)
+- Branch `idea-version-2019-1`: tags as **1.5.0+2019.1** for version **1.5.0** and idea version **2019.1**
+    - tag and github release: **1.5.0+2019.1**
+    - build.gradle: `version: '2019.1'`
+    - plugin.xml: `<idea-version since-build="191" until-build="192.*"/>`
 - Branch `master` with no version or tags, idea version **2019.1** (LATEST), no release of this branch
     - build.gradle: `version: '2019.1'`
     - plugin.xml: `<idea-version since-build="191"/>`
@@ -19,7 +23,7 @@ The code branches are based on "since-build" properties (except master).
 ## Reporting
 
 - Commit on master
-- Commits are then cherry-picked on `idea-version-2016-3` and `idea-version-2018-3`
+- Commits are then cherry-picked on `idea-version-2016-3`, `idea-version-2018-3`, and `idea-version-2019-1`
 
 ## Releasing
 
@@ -36,11 +40,15 @@ git checkout idea-version-2018-3
 ./script/release_version.sh 1.5.0
 git commit -a -m "Promote to version 1.5.0+2018.3"
 
+# For branch 2019-1, change versions, commit
+git checkout idea-version-2019-1
+./script/release_version.sh 1.5.0
+git commit -a -m "Promote to version 1.5.0+2019.1"
+
 # For the master branch
 git checkout master
 ./script/release.sh 1.5.0
 git commit -a -m "Promote to version 1.5.0"
-
 ```
 
 Then manually create a new version in [github](https://github.com/dubreuia/intellij-plugin-save-actions/releases/new).
@@ -58,10 +66,15 @@ git checkout idea-version-2016-3
 git checkout idea-version-2018-3
 ./script/build_plugin.sh
 
+# For branch 2019-1, change versions, commit
+git checkout idea-version-2019-1
+./script/build_plugin.sh
+
 # You'll have the files locally
 ls *.jar
 # intellij-plugin-save-actions-1.5.0+2016.3.jar
 # intellij-plugin-save-actions-1.5.0+2018.3.jar
+# intellij-plugin-save-actions-1.5.0+2019.1.jar
 ```
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'jacoco'
 apply plugin: 'org.jetbrains.intellij'
 
 // Add intellij task configuration for base intellij version (minimum compatibility)
-// This needs to fit the tag <idea-version since-build="181"> in plugin.xml
+// This needs to fit the tag <idea-version since-build="191"> in plugin.xml
 intellij {
     version '2019.1'
     plugins 'coverage'

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -55,7 +55,7 @@
     ]]>
     </change-notes>
 
-    <idea-version since-build="191"/>
+    <idea-version since-build="191" until-build="192.*"/>
 
     <!-- Other product support activated in plugin page during upload at https://plugins.jetbrains.com -->
     <depends optional="true" config-file="plugin-java.xml">com.intellij.modules.java</depends>


### PR DESCRIPTION
Added maximum supported platform version `192.*` i.e. `v2019.2.*`

See also https://github.com/dubreuia/intellij-plugin-save-actions/pull/260.

Fixes gh-261