### PR TITLE
Fix non reloading config

### DIFF
--- a/src/main/java/com/dubreuia/model/Storage.java
+++ b/src/main/java/com/dubreuia/model/Storage.java
@@ -11,7 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-@State(name = "SaveActionSettings", storages = {@com.intellij.openapi.components.Storage("./saveactions_settings.xml")})
+@State(name = "SaveActionSettings", storages = {@com.intellij.openapi.components.Storage("saveactions_settings.xml")})
 public class Storage implements PersistentStateComponent<Storage> {
 
     private boolean firstLaunch;


### PR DESCRIPTION
## Before this PR

Once config has been loaded once, it will not be loaded again.

## After this PR

Config is reloaded every time the `.idea/saveactions_settings.xml` file changes.
Fixes #295.

I've tested this by debugging `runIde` and noticing that originally, `Storage.loadState` would only get called once then never again, even after I modify the file.

With this change, loadState gets called every time as expected, and the UI also updates accordingly when opened.