### PR TITLE
Improvement: Add intellij 2021.3 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 // Activate junit since gradle 4.7
 test {
     useJUnitPlatform()
+    systemProperty("idea.force.use.core.classloader", "true")
 }
 
 // Add resources directory because intellij test framework checks there for test resources (instead of build/resources)

--- a/src/main/java/com/dubreuia/processors/GlobalProcessor.java
+++ b/src/main/java/com/dubreuia/processors/GlobalProcessor.java
@@ -27,20 +27,18 @@ package com.dubreuia.processors;
 
 import com.dubreuia.core.ExecutionMode;
 import com.dubreuia.model.Action;
+import com.intellij.codeInsight.CodeInsightBundle;
 import com.intellij.codeInsight.actions.OptimizeImportsProcessor;
 import com.intellij.codeInsight.actions.RearrangeCodeProcessor;
 import com.intellij.codeInsight.actions.ReformatCodeProcessor;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
-
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
-
-import static com.intellij.codeInsight.actions.RearrangeCodeProcessor.COMMAND_NAME;
 
 /**
  * Available processors for global.
@@ -57,7 +55,8 @@ public enum GlobalProcessor implements Processor {
             (project, psiFiles) -> new ReformatCodeProcessor(project, psiFiles, null, true)::run),
 
     rearrange(Action.rearrange,
-            (project, psiFiles) -> new RearrangeCodeProcessor(project, psiFiles, COMMAND_NAME, null)::run),
+            (project, psiFiles) ->
+                    new RearrangeCodeProcessor(project, psiFiles, CodeInsightBundle.message("command.rearrange.code"), null)::run),
 
     ;
 

--- a/src/main/java/com/dubreuia/processors/SaveWriteCommand.java
+++ b/src/main/java/com/dubreuia/processors/SaveWriteCommand.java
@@ -53,7 +53,8 @@ public class SaveWriteCommand extends SaveCommand {
     public Result<ResultCode> execute() {
         RunResult<ResultCode> runResult = new WriteCommandAction<ResultCode>(getProject(), getPsiFilesAsArray()) {
             @Override
-            protected void run(@NotNull com.intellij.openapi.application.Result<ResultCode> result) {
+            @SuppressWarnings("unchecked") // raw types to preserve backcompat
+            protected void run(@NotNull com.intellij.openapi.application.Result result) {
                 getCommand().apply(getProject(), getPsiFilesAsArray()).run();
                 result.setResult(OK);
             }

--- a/src/main/java/com/dubreuia/processors/java/inspection/SerializableHasSerialVersionUIDFieldInspectionWrapper.java
+++ b/src/main/java/com/dubreuia/processors/java/inspection/SerializableHasSerialVersionUIDFieldInspectionWrapper.java
@@ -43,9 +43,11 @@ public class SerializableHasSerialVersionUIDFieldInspectionWrapper {
             + "SerializableHasSerialVersionUIDFieldInspectionBase";
     private static final String CLASS_NAME_INTELLIJ_2018_3 = "com.siyeh.ig.serialization."
             + "SerializableHasSerialVersionUIDFieldInspection";
+    private static final String CLASS_NAME_INTELLIJ_2021_3 = "com.intellij.codeInspection."
+            + "SerializableHasSerialVersionUidFieldInspection";
 
     public static LocalInspectionTool get() {
-        return Stream.of(CLASS_NAME_INTELLIJ_2016, CLASS_NAME_INTELLIJ_2018_3)
+        return Stream.of(CLASS_NAME_INTELLIJ_2016, CLASS_NAME_INTELLIJ_2018_3, CLASS_NAME_INTELLIJ_2021_3)
                 .map(SerializableHasSerialVersionUIDFieldInspectionWrapper::getInspectionInstance)
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/src/main/java/com/intellij/codeInspection/visibility/CustomAccessCanBeTightenedInspection.java
+++ b/src/main/java/com/intellij/codeInspection/visibility/CustomAccessCanBeTightenedInspection.java
@@ -27,6 +27,7 @@ package com.intellij.codeInspection.visibility;
 import com.intellij.codeInsight.daemon.GroupNames;
 import com.intellij.codeInsight.daemon.impl.UnusedSymbolUtil;
 import com.intellij.codeInspection.InspectionProfile;
+import com.intellij.codeInspection.InspectionsBundle;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.codeInspection.deadCode.UnusedDeclarationInspectionBase;
 import com.intellij.openapi.progress.EmptyProgressIndicator;
@@ -66,6 +67,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.psi.util.PsiUtil;
 import com.intellij.util.VisibilityUtil;
 import com.intellij.util.containers.ContainerUtil;
+import com.siyeh.ig.GroupDisplayNameUtil;
 import com.siyeh.ig.fixes.ChangeModifierFix;
 import com.siyeh.ig.psiutils.MethodUtils;
 import gnu.trove.TObjectIntHashMap;
@@ -96,7 +98,7 @@ public class CustomAccessCanBeTightenedInspection extends com.intellij.codeInspe
   @Override
   @NotNull
   public String getGroupDisplayName() {
-    return GroupNames.VISIBILITY_GROUP_NAME;
+    return InspectionsBundle.message("group.names.visibility.issues");
   }
 
   @Override

--- a/src/test/java/com/dubreuia/integration/IntegrationTest.java
+++ b/src/test/java/com/dubreuia/integration/IntegrationTest.java
@@ -58,7 +58,7 @@ public abstract class IntegrationTest {
         fixture = factory.createCodeInsightFixture(testFixture, new LightTempDirTestFixtureImpl(true));
         fixture.setUp();
         fixture.setTestDataPath(getTestDataPath());
-        storage = ServiceManager.getService(testFixture.getProject(), Storage.class);
+        storage = testFixture.getProject().getService(Storage.class);
     }
 
     @AfterEach


### PR DESCRIPTION
In intellij 2021.3 (currently in EAP) the `SerializableHasSerialVersionUidFieldInspection` has changed the package. I had added new location to the set of the ones being search when initializing.